### PR TITLE
Modified: `FragmentHandler` returns defragmented packet as a HeapByte…

### DIFF
--- a/src/main/kotlin/io/sip3/captain/ce/pipeline/FragmentHandler.kt
+++ b/src/main/kotlin/io/sip3/captain/ce/pipeline/FragmentHandler.kt
@@ -102,8 +102,8 @@ class FragmentHandler : AbstractVerticle() {
                 expectedOffset = offset + header.totalLength - header.headerLength
             }
             // Concat all fragments
-            return Unpooled.compositeBuffer().apply {
-                buffers.forEach { (o, b) -> addComponent(b) }
+            return Unpooled.buffer(expectedOffset).apply {
+                buffers.forEach { (o, b) -> writeBytes(b) }
             }
         }
     }


### PR DESCRIPTION
…Buf instead of CompositeByteBuf