### PR TITLE
Modified: Use `setPeriodic()` instead `executeBlocking()`

### DIFF
--- a/src/test/kotlin/io/sip3/captain/ce/pipeline/IpFragmentHandlerTest.kt
+++ b/src/test/kotlin/io/sip3/captain/ce/pipeline/IpFragmentHandlerTest.kt
@@ -24,6 +24,7 @@ import io.sip3.commons.domain.payload.ByteBufPayload
 import io.sip3.commons.domain.payload.Encodable
 import io.sip3.commons.util.getBytes
 import io.sip3.commons.vertx.test.VertxTest
+import io.sip3.commons.vertx.util.setPeriodic
 import io.vertx.core.json.JsonObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -85,7 +86,9 @@ class IpFragmentHandlerTest : VertxTest() {
                 ipv4Handler.handle(packet2)
             },
             assert = {
-                vertx.executeBlocking<Any>({
+                vertx.setPeriodic(300L, 500L) {
+                    if (!packetSlot.isCaptured) return@setPeriodic
+
                     context.verify {
                         verify(timeout = 10000) { anyConstructed<Ipv4Handler>().routePacket(any()) }
                         val packet = packetSlot.captured
@@ -97,7 +100,7 @@ class IpFragmentHandlerTest : VertxTest() {
                         assertFalse(buffer.getBytes().contains(0xfe.toByte()))
                     }
                     context.completeNow()
-                }, {})
+                }
             }
         )
     }
@@ -132,7 +135,9 @@ class IpFragmentHandlerTest : VertxTest() {
                 ipv4Handler.handle(packet1)
             },
             assert = {
-                vertx.executeBlocking<Any>({
+                vertx.setPeriodic(300L, 500L) {
+                    if (!packetSlot.isCaptured) return@setPeriodic
+
                     context.verify {
                         verify(timeout = 10000) { anyConstructed<Ipv4Handler>().routePacket(any()) }
                         val packet = packetSlot.captured
@@ -144,7 +149,7 @@ class IpFragmentHandlerTest : VertxTest() {
                         assertFalse(buffer.getBytes().contains(0xfe.toByte()))
                     }
                     context.completeNow()
-                }, {})
+                }
             }
         )
     }

--- a/src/test/kotlin/io/sip3/captain/ce/pipeline/TcpHandlerTest.kt
+++ b/src/test/kotlin/io/sip3/captain/ce/pipeline/TcpHandlerTest.kt
@@ -25,6 +25,7 @@ import io.sip3.commons.domain.payload.ByteBufPayload
 import io.sip3.commons.domain.payload.Encodable
 import io.sip3.commons.vertx.test.VertxTest
 import io.sip3.commons.vertx.util.localSend
+import io.sip3.commons.vertx.util.setPeriodic
 import io.vertx.core.json.JsonObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -101,7 +102,9 @@ class TcpHandlerTest : VertxTest() {
                 vertx.eventBus().localSend(RoutesCE.tcp, listOf(packet))
             },
             assert = {
-                vertx.executeBlocking<Any>({
+                vertx.setPeriodic(300L, 500L) {
+                    if (!packetSlot.isCaptured) return@setPeriodic
+
                     context.verify {
                         verify(timeout = 20000) { anyConstructed<SipHandler>().handle(any()) }
                         val packet = packetSlot.captured
@@ -111,7 +114,7 @@ class TcpHandlerTest : VertxTest() {
                         assertEquals(21, buffer.readableBytes())
                     }
                     context.completeNow()
-                }, {})
+                }
             }
         )
     }
@@ -141,7 +144,9 @@ class TcpHandlerTest : VertxTest() {
                 vertx.eventBus().localSend(RoutesCE.tcp, listOf(packet1, packet2))
             },
             assert = {
-                vertx.executeBlocking<Any>({
+                vertx.setPeriodic(300L, 500L) {
+                    if (!packetSlot.isCaptured) return@setPeriodic
+
                     context.verify {
                         verify(timeout = 20000) { anyConstructed<SipHandler>().handle(any()) }
                         val packet = packetSlot.captured
@@ -151,7 +156,7 @@ class TcpHandlerTest : VertxTest() {
                         assertEquals(21, buffer.readableBytes())
                     }
                     context.completeNow()
-                }, {})
+                }
             }
         )
     }
@@ -180,7 +185,9 @@ class TcpHandlerTest : VertxTest() {
                 vertx.eventBus().localSend(RoutesCE.tcp, listOf(packet))
             },
             assert = {
-                vertx.executeBlocking<Any>({
+                vertx.setPeriodic(300L, 500L) {
+                    if (!packetSlot.isCaptured) return@setPeriodic
+
                     context.verify {
                         verify(timeout = 20000) { anyConstructed<SmppHandler>().handle(any()) }
                         val packet = packetSlot.captured
@@ -190,7 +197,7 @@ class TcpHandlerTest : VertxTest() {
                         assertEquals(16, buffer.readableBytes())
                     }
                     context.completeNow()
-                }, {})
+                }
             }
         )
     }


### PR DESCRIPTION
Awaiting `packetSlot.captured` initialization